### PR TITLE
unexported Clock interface

### DIFF
--- a/abc.go
+++ b/abc.go
@@ -40,9 +40,9 @@ func SetRoot(lg Logger) {
 //	logger.SetOut(os.Stdout)
 func NewSimpleLogger() WriterLogger {
 	return &SimpleLogger{
-		lvl:   LevelInfo,
-		clock: &realClock{},
-		out:   os.Stdout,
+		lvl: LevelInfo,
+		clk: &realClock{},
+		out: os.Stdout,
 	}
 }
 
@@ -58,10 +58,10 @@ func NewSimpleLogger() WriterLogger {
 //	logger.SetOut(os.Stdout)
 func NewNamedLogger(name string) WriterLogger {
 	return &NamedLogger{
-		lvl:   LevelInfo,
-		clock: &realClock{},
-		out:   os.Stdout,
-		name:  name,
+		lvl:  LevelInfo,
+		clk:  &realClock{},
+		out:  os.Stdout,
+		name: name,
 	}
 }
 
@@ -110,7 +110,7 @@ func NewNamedLogger(name string) WriterLogger {
 func NewCustomPatternLogger(pattern string) (WriterLogger, error) {
 	logger := &CustomPatternLogger{
 		lvl:     LevelInfo,
-		clock:   &realClock{},
+		clk:     &realClock{},
 		out:     os.Stdout,
 		pattern: pattern,
 	}

--- a/abc_test.go
+++ b/abc_test.go
@@ -24,9 +24,9 @@ func TestSetRoot(t *testing.T) {
 
 	// no output during tests
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelInfo,
-		out:   ioutil.Discard,
+		clk: &mockClock{},
+		lvl: LevelInfo,
+		out: ioutil.Discard,
 	}
 	SetRoot(l)
 
@@ -35,9 +35,9 @@ func TestSetRoot(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelInfo,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelInfo,
+		out: buf,
 	}
 	SetRoot(logger) // set new root logger
 
@@ -61,7 +61,7 @@ func TestNewSimpleLogger(t *testing.T) {
 	// check default out
 	assert.Equal(logger.out, os.Stdout)
 	// check default clock type (must be real clock)
-	_, ok = logger.clock.(*realClock)
+	_, ok = logger.clk.(*realClock)
 	assert.True(ok, "Clock was expected to be of type *realClock, but was not.")
 }
 
@@ -81,7 +81,7 @@ func TestNewNamedLogger(t *testing.T) {
 	// check default out
 	assert.Equal(logger.out, os.Stdout)
 	// check default clock type (must be real clock)
-	_, ok = logger.clock.(*realClock)
+	_, ok = logger.clk.(*realClock)
 	assert.True(ok, "Clock was expected to be of type *realClock, but was not.")
 	// check name
 	assert.Equalf(logger.name, name, "Expected name of logger to be '%v', but was '%v'.", name, logger.name)
@@ -104,7 +104,7 @@ func TestNewCustomPatternLogger(t *testing.T) {
 	// check default out
 	assert.Equal(logger.out, os.Stdout)
 	// check default clock type (must be real clock)
-	_, ok = logger.clock.(*realClock)
+	_, ok = logger.clk.(*realClock)
 	assert.True(ok, "Clock was expected to be of type *realClock, but was not.")
 	// check pattern
 	assert.Equalf(logger.pattern, pattern, "Expected pattern of logger to be '%v', but was '%v'.", pattern, logger.pattern)
@@ -146,9 +146,9 @@ func Test_All_Outputs(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf,
 	}
 	SetRoot(logger)
 
@@ -218,9 +218,9 @@ func TestSetLevel(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelInfo,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelInfo,
+		out: buf,
 	}
 	SetRoot(logger) // set new root logger
 

--- a/clock.go
+++ b/clock.go
@@ -2,9 +2,9 @@ package abc
 
 import "time"
 
-// Clock is an interface created to be able to
+// clockT is an interface created to be able to
 // mock time.Now() easily.
-type Clock interface {
+type clockT interface {
 	Now() time.Time
 	After(d time.Duration) <-chan time.Time
 }

--- a/clock.go
+++ b/clock.go
@@ -4,7 +4,7 @@ import "time"
 
 // clockT is an interface created to be able to
 // mock time.Now() easily.
-type clockT interface {
+type clock interface {
 	Now() time.Time
 	After(d time.Duration) <-chan time.Time
 }

--- a/colored_logger_bench_test.go
+++ b/colored_logger_bench_test.go
@@ -7,9 +7,9 @@ import (
 func BenchmarkColoredLogger_SimpleLogger_Printf(b *testing.B) {
 	logger := &ColoredLogger{
 		wrapped: &SimpleLogger{
-			clock: &mockClock{},
-			lvl:   LevelVerbose,
-			out:   &MockWriter{},
+			clk: &mockClock{},
+			lvl: LevelVerbose,
+			out: &MockWriter{},
 		},
 	}
 	b.ReportAllocs()

--- a/colored_logger_test.go
+++ b/colored_logger_test.go
@@ -13,9 +13,9 @@ func TestColoredLogger_Printf(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelDebug,
+		out: buf,
 	}
 
 	logger := &ColoredLogger{
@@ -110,9 +110,9 @@ func TestColoredLogger_Print(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelDebug,
+		out: buf,
 	}
 
 	logger := &ColoredLogger{
@@ -216,9 +216,9 @@ func TestColoredLogger_All_Outputs(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf,
 	}
 
 	logger := &ColoredLogger{
@@ -273,9 +273,9 @@ func TestColoredLogger_SetOut(t *testing.T) {
 	buf2 := &bytes.Buffer{}
 
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf1,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf1,
 	}
 
 	logger := &ColoredLogger{
@@ -313,9 +313,9 @@ func TestColoredLogger_SetLevel(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	l := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf,
 	}
 
 	logger := &ColoredLogger{

--- a/custom_pattern_logger.go
+++ b/custom_pattern_logger.go
@@ -68,7 +68,7 @@ type CustomPatternLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    Clock
+	clock    clockT
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -235,12 +235,12 @@ func (l *CustomPatternLogger) IsLevelEnabled(lvl LogLevel) bool {
 }
 
 // Clock returns the clock of this logger.
-func (l *CustomPatternLogger) Clock() Clock {
+func (l *CustomPatternLogger) Clock() clockT {
 	return l.clock
 }
 
 // SetClock sets a new clock for this logger.
-func (l *CustomPatternLogger) SetClock(clock Clock) {
+func (l *CustomPatternLogger) SetClock(clock clockT) {
 	l.clockMux.Lock()
 	defer l.clockMux.Unlock()
 	l.clock = clock
@@ -261,7 +261,7 @@ func (l *CustomPatternLogger) SetOut(out io.Writer) {
 // =======================================================
 
 type customPatternLoggerTemplateData struct {
-	clock   Clock
+	clock   clockT
 	Level   string
 	Message string
 

--- a/custom_pattern_logger.go
+++ b/custom_pattern_logger.go
@@ -68,7 +68,7 @@ type CustomPatternLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    clockT
+	clk      clock
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -115,7 +115,7 @@ func (l *CustomPatternLogger) prepareMessage(lvl LogLevel, a string) string {
 
 	buf := &bytes.Buffer{}
 	err := l.template.Execute(buf, &customPatternLoggerTemplateData{
-		clock:   l.clock,
+		clk:     l.clk,
 		Level:   fmt.Sprintf("%-4v", lvl.String()),
 		Message: a,
 	})
@@ -234,16 +234,16 @@ func (l *CustomPatternLogger) IsLevelEnabled(lvl LogLevel) bool {
 	return lvl >= l.Level()
 }
 
-// Clock returns the clock of this logger.
-func (l *CustomPatternLogger) Clock() clockT {
-	return l.clock
+// clock returns the clock of this logger.
+func (l *CustomPatternLogger) clock() clock {
+	return l.clk
 }
 
 // SetClock sets a new clock for this logger.
-func (l *CustomPatternLogger) SetClock(clock clockT) {
+func (l *CustomPatternLogger) SetClock(clk clock) {
 	l.clockMux.Lock()
 	defer l.clockMux.Unlock()
-	l.clock = clock
+	l.clk = clk
 }
 
 // Out returns the writer of this logger.
@@ -261,7 +261,7 @@ func (l *CustomPatternLogger) SetOut(out io.Writer) {
 // =======================================================
 
 type customPatternLoggerTemplateData struct {
-	clock   clockT
+	clk     clock
 	Level   string
 	Message string
 
@@ -278,7 +278,7 @@ func (l *customPatternLoggerTemplateData) Timestamp() string {
 }
 
 func (l *customPatternLoggerTemplateData) Timestampf(layout string) string {
-	return l.clock.Now().Format(layout) // the formatted timestamp
+	return l.clk.Now().Format(layout) // the formatted timestamp
 }
 
 func (l *customPatternLoggerTemplateData) File() string {

--- a/custom_pattern_logger_bench_test.go
+++ b/custom_pattern_logger_bench_test.go
@@ -6,7 +6,7 @@ import (
 
 func BenchmarkCustomPatternLogger_Printf(b *testing.B) {
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     &MockWriter{},
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",
@@ -21,7 +21,7 @@ func BenchmarkCustomPatternLogger_Printf(b *testing.B) {
 }
 func BenchmarkCustomPatternLogger_Printf_Stack_Ops(b *testing.B) {
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     &MockWriter{},
 		pattern: "{{.Timestamp}} {{.File}}:{{.Line}} {{.Function}} [{{.Level}}] - {{.Message}}\n",

--- a/custom_pattern_logger_stackops_line_test.go
+++ b/custom_pattern_logger_stackops_line_test.go
@@ -29,7 +29,7 @@ func TestCustomPatternLogger_Stackops_Line(t *testing.T) {
 	}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf,
 		pattern: `{{.Line}}`,

--- a/custom_pattern_logger_stackops_test.go
+++ b/custom_pattern_logger_stackops_test.go
@@ -13,7 +13,7 @@ func TestCustomPatternLogger_Stackops_File(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf,
 		pattern: `{{.File}} {{.Filef "short"}}`,
@@ -71,7 +71,7 @@ func TestCustomPatternLogger_Stackops_Function(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf,
 		pattern: `{{.Function}} {{.Functionf "short"}} {{.Functionf "full"}} {{.Functionf "package"}}`,

--- a/custom_pattern_logger_test.go
+++ b/custom_pattern_logger_test.go
@@ -12,7 +12,7 @@ func TestCustomPatternLogger_Printf(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelDebug,
 		out:     buf,
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",
@@ -82,7 +82,7 @@ func TestCustomPatternLogger_Print(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelDebug,
 		out:     buf,
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",
@@ -188,7 +188,7 @@ func TestCustomPatternLogger_All_Outputs(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf,
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",
@@ -250,7 +250,7 @@ func TestCustomPatternLogger_SetOut(t *testing.T) {
 	buf2 := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf1,
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",
@@ -285,7 +285,7 @@ func TestCustomPatternLogger_SetLevel(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &CustomPatternLogger{
-		clock:   &mockClock{},
+		clk:     &mockClock{},
 		lvl:     LevelVerbose,
 		out:     buf,
 		pattern: "{{.Timestamp}} [{{.Level}}] - {{.Message}}\n",

--- a/named_logger.go
+++ b/named_logger.go
@@ -20,7 +20,7 @@ type NamedLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    Clock
+	clock    clockT
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -147,12 +147,12 @@ func (l *NamedLogger) IsLevelEnabled(lvl LogLevel) bool {
 }
 
 // Clock returns the clock of this logger.
-func (l *NamedLogger) Clock() Clock {
+func (l *NamedLogger) Clock() clockT {
 	return l.clock
 }
 
 // SetClock sets a new clock for this logger.
-func (l *NamedLogger) SetClock(clock Clock) {
+func (l *NamedLogger) SetClock(clock clockT) {
 	l.clockMux.Lock()
 	defer l.clockMux.Unlock()
 	l.clock = clock

--- a/named_logger.go
+++ b/named_logger.go
@@ -20,7 +20,7 @@ type NamedLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    clockT
+	clk      clock
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -48,7 +48,7 @@ func (l *NamedLogger) Printf(lvl LogLevel, format string, v ...interface{}) {
 }
 
 func (l *NamedLogger) prepareMessage(lvl LogLevel, a string) string {
-	return fmt.Sprintf("%v <%-v> [%-4v] - %v\n", l.clock.Now().Format(TimeLayoutNamedLogger), l.name, lvl.String(), a)
+	return fmt.Sprintf("%v <%-v> [%-4v] - %v\n", l.clk.Now().Format(TimeLayoutNamedLogger), l.name, lvl.String(), a)
 }
 
 func (l *NamedLogger) print0(a string) {
@@ -146,16 +146,16 @@ func (l *NamedLogger) IsLevelEnabled(lvl LogLevel) bool {
 	return lvl >= l.Level()
 }
 
-// Clock returns the clock of this logger.
-func (l *NamedLogger) Clock() clockT {
-	return l.clock
+// clock returns the clock of this logger.
+func (l *NamedLogger) clock() clock {
+	return l.clk
 }
 
 // SetClock sets a new clock for this logger.
-func (l *NamedLogger) SetClock(clock clockT) {
+func (l *NamedLogger) SetClock(clk clock) {
 	l.clockMux.Lock()
 	defer l.clockMux.Unlock()
-	l.clock = clock
+	l.clk = clk
 }
 
 // Out returns the writer of this logger.

--- a/named_logger_bench_test.go
+++ b/named_logger_bench_test.go
@@ -6,10 +6,10 @@ import (
 
 func BenchmarkNamedLogger_Printf(b *testing.B) {
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   &MockWriter{},
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelVerbose,
+		out:  &MockWriter{},
+		name: "MyLogger",
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/named_logger_test.go
+++ b/named_logger_test.go
@@ -12,10 +12,10 @@ func TestNamedLogger_Printf(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelDebug,
+		out:  buf,
+		name: "MyLogger",
 	}
 
 	type args struct {
@@ -82,10 +82,10 @@ func TestNamedLogger_Print(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelDebug,
+		out:  buf,
+		name: "MyLogger",
 	}
 
 	type args struct {
@@ -188,10 +188,10 @@ func TestNamedLogger_All_Outputs(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelVerbose,
+		out:  buf,
+		name: "MyLogger",
 	}
 
 	check := func() {
@@ -250,10 +250,10 @@ func TestNamedLogger_SetOut(t *testing.T) {
 	buf2 := &bytes.Buffer{}
 
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf1,
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelVerbose,
+		out:  buf1,
+		name: "MyLogger",
 	}
 
 	logger.Info("foo")
@@ -285,10 +285,10 @@ func TestNamedLogger_SetLevel(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &NamedLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
-		name:  "MyLogger",
+		clk:  &mockClock{},
+		lvl:  LevelVerbose,
+		out:  buf,
+		name: "MyLogger",
 	}
 
 	logger.Verbose("foo")

--- a/simple_logger.go
+++ b/simple_logger.go
@@ -19,7 +19,7 @@ type SimpleLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    clockT
+	clk      clock
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -44,7 +44,7 @@ func (s *SimpleLogger) Printf(lvl LogLevel, format string, v ...interface{}) {
 }
 
 func (s *SimpleLogger) prepareMessage(lvl LogLevel, a string) string {
-	return fmt.Sprintf("%v [%-4v] - %v\n", s.clock.Now().Format(TimeLayoutSimpleLogger), lvl.String(), a)
+	return fmt.Sprintf("%v [%-4v] - %v\n", s.clk.Now().Format(TimeLayoutSimpleLogger), lvl.String(), a)
 }
 
 func (s *SimpleLogger) print0(a string) {
@@ -141,16 +141,16 @@ func (s *SimpleLogger) IsLevelEnabled(lvl LogLevel) bool {
 	return lvl >= s.Level()
 }
 
-// Clock returns the clock of this logger.
-func (s *SimpleLogger) Clock() clockT {
-	return s.clock
+// clock returns the clock of this logger.
+func (s *SimpleLogger) clock() clock {
+	return s.clk
 }
 
 // SetClock sets a new clock for this logger.
-func (s *SimpleLogger) SetClock(clock clockT) {
+func (s *SimpleLogger) SetClock(clk clock) {
 	s.clockMux.Lock()
 	defer s.clockMux.Unlock()
-	s.clock = clock
+	s.clk = clk
 }
 
 // Out returns the writer of this logger.

--- a/simple_logger.go
+++ b/simple_logger.go
@@ -19,7 +19,7 @@ type SimpleLogger struct {
 	lvl    LogLevel
 
 	clockMux sync.Mutex
-	clock    Clock
+	clock    clockT
 
 	outMux sync.Mutex
 	out    io.Writer
@@ -142,12 +142,12 @@ func (s *SimpleLogger) IsLevelEnabled(lvl LogLevel) bool {
 }
 
 // Clock returns the clock of this logger.
-func (s *SimpleLogger) Clock() Clock {
+func (s *SimpleLogger) Clock() clockT {
 	return s.clock
 }
 
 // SetClock sets a new clock for this logger.
-func (s *SimpleLogger) SetClock(clock Clock) {
+func (s *SimpleLogger) SetClock(clock clockT) {
 	s.clockMux.Lock()
 	defer s.clockMux.Unlock()
 	s.clock = clock

--- a/simple_logger_bench_test.go
+++ b/simple_logger_bench_test.go
@@ -6,9 +6,9 @@ import (
 
 func BenchmarkSimpleLogger_Printf(b *testing.B) {
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   &MockWriter{},
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: &MockWriter{},
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/simple_logger_test.go
+++ b/simple_logger_test.go
@@ -12,9 +12,9 @@ func TestSimpleLogger_Printf(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelDebug,
+		out: buf,
 	}
 
 	type args struct {
@@ -81,9 +81,9 @@ func TestSimpleLogger_Print(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelDebug,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelDebug,
+		out: buf,
 	}
 
 	type args struct {
@@ -186,9 +186,9 @@ func TestSimpleLogger_All_Outputs(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf,
 	}
 
 	check := func() {
@@ -247,9 +247,9 @@ func TestSimpleLogger_SetOut(t *testing.T) {
 	buf2 := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf1,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf1,
 	}
 
 	logger.Info("foo")
@@ -281,9 +281,9 @@ func TestSimpleLogger_SetLevel(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	logger := &SimpleLogger{
-		clock: &mockClock{},
-		lvl:   LevelVerbose,
-		out:   buf,
+		clk: &mockClock{},
+		lvl: LevelVerbose,
+		out: buf,
 	}
 
 	logger.Verbose("foo")


### PR DESCRIPTION
fix issue #7

I preferred renaming Clock interface to clockT to avoid naming conflicts with variables named 'clock'

